### PR TITLE
Typo "navegation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,8 @@ Zumly is on early stages of development.
 
 - Allow different template engines. Currently Zumly only accepts string literal templates.
 - Add lateral navigation for same zoom level elements.
-- Add a navegation widget.
-- Add programmatic navegation.
+- Add a navigation widget.
+- Add programmatic navigation.
 - Allow recalculate zoom position on resize events.
 
 


### PR DESCRIPTION
Actually not sure about this pull request since that "navegation" perhaps could be Zumly's exclusive name for "navigation"?