### PR TITLE
Svelte component classes as views

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -149,7 +149,11 @@ export async function renderView (el, canvas, views, init, componentContext) {
     } else if(typeof views[viewName] === 'function') {
       // view is a component constructor
       var newViewInner = document.createElement('div')
-      let comp = new views[viewName]({ target: newViewInner, context: componentContext })
+      let comp = new views[viewName]({ 
+        target: newViewInner, 
+        context: componentContext,
+        props: el.dataset
+      })
       newView.content.appendChild(newViewInner)      
     } else {
       // view is plain HTML

--- a/src/utils.js
+++ b/src/utils.js
@@ -148,18 +148,16 @@ export async function renderView (el, canvas, views, init) {
       newView.innerHTML = await views[viewName].render()
     } else if(typeof views[viewName] === 'function') {
       // view is a component constructor
-      let comp = new views[viewName]({target: newView})
-      //newView.innerHTML = comp.$$.root
+      var newViewInner = document.createElement('div')
+      let comp = new views[viewName]({target: newViewInner})
+      newView.content.appendChild(newViewInner)      
     } else {
       // view is plain HTML
       newView.innerHTML = views[viewName]
     }
-    
 
     let vv = newView.content.querySelector('.z-view')
 
-    
-    /*
     if (!init) {
       vv.classList.add('is-new-current-view')
       vv.classList.add('has-no-events')
@@ -170,7 +168,7 @@ export async function renderView (el, canvas, views, init) {
     }
     vv.style.transformOrigin = '0 0'
     vv.dataset.viewName = viewName
-    */
+    
     var appendedView = await canvas.append(newView.content)
     // makes optional de 'mounted' hook
     if (typeof views[viewName] === 'object' && views[viewName].mounted !== undefined && typeof views[viewName].mounted() === 'function') await views[viewName].mounted()

--- a/src/utils.js
+++ b/src/utils.js
@@ -142,12 +142,24 @@ export async function renderView (el, canvas, views, init) {
     var viewName = null
     init ? viewName = el : viewName = el.dataset.to
     var newView = document.createElement('template')
-    // makes optional de 'render' function
-    typeof views[viewName] === 'object' && views[viewName].render !== undefined
-      ? newView.innerHTML = await views[viewName].render()
-      : newView.innerHTML = views[viewName]
+    
+    if(typeof views[viewName] === 'object' && views[viewName].render !== undefined) {      
+      // makes optional de 'render' function
+      newView.innerHTML = await views[viewName].render()
+    } else if(typeof views[viewName] === 'function') {
+      // view is a component constructor
+      let comp = new views[viewName]({target: newView})
+      //newView.innerHTML = comp.$$.root
+    } else {
+      // view is plain HTML
+      newView.innerHTML = views[viewName]
+    }
+    
 
-    const vv = newView.content.querySelector('.z-view')
+    let vv = newView.content.querySelector('.z-view')
+
+    
+    /*
     if (!init) {
       vv.classList.add('is-new-current-view')
       vv.classList.add('has-no-events')
@@ -158,6 +170,7 @@ export async function renderView (el, canvas, views, init) {
     }
     vv.style.transformOrigin = '0 0'
     vv.dataset.viewName = viewName
+    */
     var appendedView = await canvas.append(newView.content)
     // makes optional de 'mounted' hook
     if (typeof views[viewName] === 'object' && views[viewName].mounted !== undefined && typeof views[viewName].mounted() === 'function') await views[viewName].mounted()

--- a/src/utils.js
+++ b/src/utils.js
@@ -138,7 +138,7 @@ export function setCSSVariables (transition, currentStage, instance) {
   })
 }
 
-export async function renderView (el, canvas, views, init) {
+export async function renderView (el, canvas, views, init, componentContext) {
     var viewName = null
     init ? viewName = el : viewName = el.dataset.to
     var newView = document.createElement('template')
@@ -149,7 +149,7 @@ export async function renderView (el, canvas, views, init) {
     } else if(typeof views[viewName] === 'function') {
       // view is a component constructor
       var newViewInner = document.createElement('div')
-      let comp = new views[viewName]({target: newViewInner})
+      let comp = new views[viewName]({ target: newViewInner, context: componentContext })
       newView.content.appendChild(newViewInner)      
     } else {
       // view is plain HTML
@@ -202,6 +202,8 @@ export function checkParameters (parameters, instance) {
     validate(instance, 'views', parameters.views, 'object', { isRequired: true })
     // debug property. Boolean. Optional. Default false
     validate(instance, 'debug', parameters.debug, 'boolean', { defaultValue: false })
+    // Svelte component context
+    validate(instance, 'componentContext', parameters.componentContext, 'object', { isRequired: false, defaultValue: new Map() })
     // Check transtions
     if (parameters.transitions && typeof parameters.transitions === 'object') {
       // value exist; type, allowed, deafult

--- a/src/utils.js
+++ b/src/utils.js
@@ -154,6 +154,7 @@ export async function renderView (el, canvas, views, init, componentContext) {
         context: componentContext,
         props: el.dataset
       })
+      newViewInner.classList.add('z-view')
       newView.content.appendChild(newViewInner)      
     } else {
       // view is plain HTML

--- a/src/zumly.js
+++ b/src/zumly.js
@@ -461,7 +461,19 @@ export class Zumly {
     element.removeEventListener('animationend', this._onZoomOutHandlerEnd)
     // current
     if (element.classList.contains(`zoom-current-view-${this.instance}`)) {
-      this.canvas.removeChild(element)
+      try {
+        this.canvas.removeChild(element)  
+      } catch(e) {
+        console.debug("Error when trying to remove element after zoom out. Trying to remove its parent instead...")
+        try {
+          this.canvas.removeChild(element.parentElement)  
+        } catch(e) {
+          console.debug("Error when trying to remove elemont after zoom out:", e)
+          console.debug("Element to remove was:", element)
+        }
+        
+      }
+      
       this.blockEvents = false
     }
     if (element.classList.contains(`zoom-previous-view-${this.instance}`)) {

--- a/src/zumly.js
+++ b/src/zumly.js
@@ -117,7 +117,7 @@ export class Zumly {
       // add instance style
       this.tracing('init()')
       prepareCSS(this.instance)
-      await renderView(this.initialView, this.canvas, this.views, 'init')
+      await renderView(this.initialView, this.canvas, this.views, 'init', this.componentContext)
       // add to storage. OPTIMIZAR
       this.storeViews({
         zoomLevel: this.storedViews.length,
@@ -152,7 +152,7 @@ export class Zumly {
     // generated new view from activated .zoom-me element
     // generateNewView(el)
     this.tracing('renderView()')
-    await renderView(el, canvas, this.views)
+    await renderView(el, canvas, this.views, this.componentContext)
     el.classList.add('zoomed')
     const coordenadasEl = el.getBoundingClientRect()
     // create new view in a template tag

--- a/src/zumly.js
+++ b/src/zumly.js
@@ -152,7 +152,7 @@ export class Zumly {
     // generated new view from activated .zoom-me element
     // generateNewView(el)
     this.tracing('renderView()')
-    await renderView(el, canvas, this.views, this.componentContext)
+    await renderView(el, canvas, this.views, false, this.componentContext)
     el.classList.add('zoomed')
     const coordenadasEl = el.getBoundingClientRect()
     // create new view in a template tag


### PR DESCRIPTION
# Simply add Svelte component constructors as views
In your Svelte main/root component:
```svelte
<script lang="ts">
  import { getAllContexts, onMount } from "svelte";
  import Zumly from 'zumly'

  // Some Svelte components in your project:
  import ZoomRoot from './ZoomRoot.svelte'
  import Perspective from './Perspective.svelte'
  
  const allContexts = getAllContexts()

  onMount(()=> {
    const zumly = new Zumly({
	    mount: '#zoom-container',
	    initialView: 'ZoomRoot',
	    views: {
		    ZoomRoot,
		    Perspective,
	    },
            // NEW PARAMETER:
	    componentContext: allContexts,
    })
  
    zumly.init()
  })
</script>

<div id="zoom-container"></div>
```

Note the new Zumly constructor parameter `componentContext` which should be initialized with Svelte's `getAllContexts()` as in the example above to have components instantiated by Zumly find a non-empty global context.

The new code checks if the view to instantiate is `typeof == 'function'` and then calls it with `new`, passing an options object as expected by Svelte component constructors, injecting component properties and the global Svelte context.

# Pass component properties as data-attributes
Properties can be provided via `data-` attributes from the markup that defines the zoom-me handle:

```svelte
{#each $perspectives as perspective}
  <span class="zoom-me" data-to="Perspective" data-uuid={perspective.uuid}>
      {perspective.name}
  </span>
{/each}
```

So the above is equivalent to 
```svelte
{#each $perspectives as perspective}
  <Perspective uuid={perspective.uuid}></Perspective>
{/each}
```
But wrapping each `Perspective` component with a Zumly zooming layer.

